### PR TITLE
feat: Migrate state saving from rl profile to rs profile

### DIFF
--- a/src/main/java/com/cluesaver/ClueSaverPlugin.java
+++ b/src/main/java/com/cluesaver/ClueSaverPlugin.java
@@ -31,6 +31,7 @@ import com.cluesaver.ids.ToaChest;
 import com.cluesaver.ids.TobChest;
 import com.google.inject.Provides;
 import java.awt.Color;
+import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -138,19 +139,25 @@ public class ClueSaverPlugin extends Plugin
 	@Inject
 	private MouseManager mouseManager;
 
-	private boolean profileChanged;
 	private int casketCooldown;
 	private boolean loggingIn;
+	private String profileKey;
 
 	@Override
 	protected void startUp() throws Exception
 	{
+		profileKey = null;
 		overlayManager.add(infoOverlay);
-		tierSaveManager.loadStateFromConfig();
 		overlayManager.add(clueSaverUI);
 		clueSaverUI.setVisible(true);
 		mouseManager.registerMouseListener(clueSaverUI);
 		loggingIn = true;
+
+		String profileKey = configManager.getRSProfileKey();
+		if (profileKey != null)
+		{
+			switchProfile(profileKey);
+		}
 	}
 
 	@Override
@@ -158,7 +165,7 @@ public class ClueSaverPlugin extends Plugin
 	{
 		overlayManager.remove(infoOverlay);
 		removeInfoBox();
-		tierSaveManager.saveStateToConfig();
+		tierSaveManager.saveStateToConfig(profileKey);
 		overlayManager.remove(clueSaverUI);
 		clueSaverUI.setVisible(false);
 		mouseManager.unregisterMouseListener(clueSaverUI);
@@ -169,16 +176,7 @@ public class ClueSaverPlugin extends Plugin
 	{
 		if (event.getGameState() == GameState.LOGIN_SCREEN)
 		{
-			tierSaveManager.saveStateToConfig();
-		}
-
-		if (event.getGameState() == GameState.LOGGED_IN)
-		{
-			if (profileChanged)
-			{
-				profileChanged = false;
-				tierSaveManager.loadStateFromConfig();
-			}
+			tierSaveManager.saveStateToConfig(profileKey);
 		}
 
 		if (event.getGameState() == GameState.LOGGING_IN)
@@ -190,13 +188,37 @@ public class ClueSaverPlugin extends Plugin
 	@Subscribe
 	public void onRuneScapeProfileChanged(RuneScapeProfileChanged event)
 	{
-		profileChanged = true;
+		final String profileKey = configManager.getRSProfileKey();
+		if (profileKey == null)
+		{
+			return;
+		}
+
+		if (profileKey.equals(this.profileKey))
+		{
+			return;
+		}
+
+		switchProfile(profileKey);
+	}
+
+	private void switchProfile(String profileKey)
+	{
+		// Save data to previous profile
+		tierSaveManager.saveStateToConfig(this.profileKey);
+
+		this.profileKey = profileKey;
+		log.debug("Switched to profile {}", profileKey);
+
+		// Save data from current profile
+		migrateConfig();
+		tierSaveManager.loadStateFromConfig();
 	}
 
 	@Subscribe(priority = 100)
 	private void onClientShutdown(ClientShutdown event)
 	{
-		tierSaveManager.saveStateToConfig();
+		tierSaveManager.saveStateToConfig(profileKey);
 	}
 
 	@Subscribe
@@ -231,6 +253,37 @@ public class ClueSaverPlugin extends Plugin
 		{
 			checkReward();
 		}
+	}
+
+	private void migrateToRSProfile(String stateKey)
+	{
+		String tierStateJson = configManager.getConfiguration(ClueSaverConfig.GROUP, stateKey);
+
+		if (tierStateJson != null)
+		{
+			configManager.setRSProfileConfiguration(ClueSaverConfig.GROUP, stateKey, tierStateJson);
+			configManager.unsetConfiguration(ClueSaverConfig.GROUP, stateKey);
+		}
+	}
+
+	private void migrateConfig()
+	{
+		String migrated = configManager.getConfiguration(ClueSaverConfig.GROUP, "migrated");
+		if ("1".equals(migrated))
+		{
+			return;
+		}
+
+		List.of(
+			ClueSaverConfig.BEGINNER_STATE,
+			ClueSaverConfig.EASY_STATE,
+			ClueSaverConfig.MEDIUM_STATE,
+			ClueSaverConfig.HARD_STATE,
+			ClueSaverConfig.ELITE_STATE,
+			ClueSaverConfig.MASTER_STATE
+		).forEach(this::migrateToRSProfile);
+
+		configManager.setConfiguration(ClueSaverConfig.GROUP, "migrated", 1);
 	}
 
 	private void checkBank()

--- a/src/main/java/com/cluesaver/ClueStates.java
+++ b/src/main/java/com/cluesaver/ClueStates.java
@@ -294,4 +294,16 @@ public class ClueStates
 		boxState.setInventoryCount(loadedTierData.getScrollBoxInventoryCount());
 		boxState.setBankCount(loadedTierData.getScrollBoxBankCount());
 	}
+
+	public void resetTierState(ClueTier tier)
+	{
+		// Reset tier clue scroll state
+		ClueScrollState scrollState = getClueStateFromTier(tier);
+		scrollState.setLocation(ClueLocation.UNKNOWN);
+
+		// Reset tier scroll box states
+		ScrollBoxState boxState = getBoxStateFromTier(tier);
+		boxState.setInventoryCount(0);
+		boxState.setBankCount(0);
+	}
 }

--- a/src/main/java/com/cluesaver/TierStateSaveManager.java
+++ b/src/main/java/com/cluesaver/TierStateSaveManager.java
@@ -48,32 +48,27 @@ public class TierStateSaveManager
 		this.gson = gson;
 	}
 
-	public void saveStateToConfig()
+	private void saveTierToConfig(String profileKey, ClueTier tier, String configKey)
 	{
-		// Serialize tier states save to config
-		TierState beginnerState = getTierData(ClueTier.BEGINNER);
-		String beginnerStateData = gson.toJson(beginnerState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.BEGINNER_STATE, beginnerStateData);
+		// Serialize tier state and save to config
+		TierState state = getTierData(tier);
+		String stateData = gson.toJson(state);
+		configManager.setConfiguration(ClueSaverConfig.GROUP, profileKey, configKey, stateData);
+	}
 
-		TierState easyState = getTierData(ClueTier.EASY);
-		String easyStateData = gson.toJson(easyState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.EASY_STATE, easyStateData);
+	public void saveStateToConfig(String profileKey)
+	{
+		if (profileKey == null)
+		{
+			return;
+		}
 
-		TierState mediumState = getTierData(ClueTier.MEDIUM);
-		String mediumStateData = gson.toJson(mediumState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.MEDIUM_STATE, mediumStateData);
-
-		TierState hardState = getTierData(ClueTier.HARD);
-		String hardStateData = gson.toJson(hardState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.HARD_STATE, hardStateData);
-
-		TierState eliteState = getTierData(ClueTier.ELITE);
-		String eliteStateData = gson.toJson(eliteState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.ELITE_STATE, eliteStateData);
-
-		TierState masterState = getTierData(ClueTier.MASTER);
-		String masterStateData = gson.toJson(masterState);
-		configManager.setConfiguration(ClueSaverConfig.GROUP, ClueSaverConfig.MASTER_STATE, masterStateData);
+		saveTierToConfig(profileKey, ClueTier.BEGINNER, ClueSaverConfig.BEGINNER_STATE);
+		saveTierToConfig(profileKey, ClueTier.EASY, ClueSaverConfig.EASY_STATE);
+		saveTierToConfig(profileKey, ClueTier.MEDIUM, ClueSaverConfig.MEDIUM_STATE);
+		saveTierToConfig(profileKey, ClueTier.HARD, ClueSaverConfig.HARD_STATE);
+		saveTierToConfig(profileKey, ClueTier.ELITE, ClueSaverConfig.ELITE_STATE);
+		saveTierToConfig(profileKey, ClueTier.MASTER, ClueSaverConfig.MASTER_STATE);
 	}
 
 	private TierState getTierData(ClueTier tier)
@@ -101,7 +96,7 @@ public class TierStateSaveManager
 
 	public void loadTierFromConfig(String key, ClueTier tier)
 	{
-		String tierStateJson = configManager.getConfiguration(ClueSaverConfig.GROUP, key);
+		String tierStateJson = configManager.getRSProfileConfiguration(ClueSaverConfig.GROUP, key);
 
 		if (tierStateJson != null)
 		{
@@ -120,6 +115,11 @@ public class TierStateSaveManager
 			{
 				log.error("e: ", err);
 			}
+		}
+		// We have no data for this tier. Reset to unknown state
+		else
+		{
+			clueSaverPlugin.getClueStates().resetTierState(tier);
 		}
 	}
 }


### PR DESCRIPTION
Store unique clue state data on the RS account rather than per Runelite profile

Closes #33 